### PR TITLE
feat(motion-light): status LED, deep-sleep join, and HA controls

### DIFF
--- a/zigbee-motion-light/README.md
+++ b/zigbee-motion-light/README.md
@@ -64,6 +64,23 @@ This basic version builds successfully. To add Zigbee functionality:
 3. Configure Zigbee settings in `sdkconfig.defaults`
 4. Implement Zigbee occupancy and on/off clusters
 
+## Deep sleep & Zigbee rejoin
+
+The device wakes from deep sleep, rejoins the Zigbee network using credentials stored in the `zb_storage` flash partition, sends occupancy, and sleeps again. Typical rejoin time is **~0.7–2 s**.
+
+See **[docs/nvram-rejoin-and-diagnostics.md](docs/nvram-rejoin-and-diagnostics.md)** for:
+
+- NVRAM snapshot log format and how to verify `zb_storage` restore
+- Expected serial output after sleep/wake
+- Signal handler behavior (`DEVICE_REBOOT` vs steering)
+- Flash erase vs firmware-only update
+
+For a clean pairing test:
+
+```bash
+idf.py -p <PORT> erase-flash flash monitor
+```
+
 ## Configuration
 
 Edit `sdkconfig.defaults` for custom settings or use `idf.py menuconfig`.

--- a/zigbee-motion-light/components/light_animation/CMakeLists.txt
+++ b/zigbee-motion-light/components/light_animation/CMakeLists.txt
@@ -1,5 +1,5 @@
 idf_component_register(
     SRCS "light_animation.c"
     INCLUDE_DIRS "."
-    REQUIRES light_driver motion_driver zigbee_motion
+    REQUIRES light_driver motion_driver motion_status_led zigbee_motion esp_timer
 )

--- a/zigbee-motion-light/components/light_animation/CMakeLists.txt
+++ b/zigbee-motion-light/components/light_animation/CMakeLists.txt
@@ -1,5 +1,5 @@
 idf_component_register(
     SRCS "light_animation.c"
     INCLUDE_DIRS "."
-    REQUIRES light_driver motion_driver
+    REQUIRES light_driver motion_driver zigbee_motion
 )

--- a/zigbee-motion-light/components/light_animation/light_animation.c
+++ b/zigbee-motion-light/components/light_animation/light_animation.c
@@ -5,23 +5,23 @@
  *
  * Light Animation Component
  *
- * This component monitors the motion driver state and runs LED animations
- * while motion is detected.
+ * Pixel 0: Zigbee link status. Pixel 1: motion status. Pixel 2+: main animation.
  */
 
 #include "esp_log.h"
+#include "esp_timer.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 #include "freertos/event_groups.h"
 #include "light_animation.h"
 #include "light_driver.h"
 #include "motion_driver.h"
+#include "motion_status_led.h"
 #include "zigbee_motion.h"
 
 static const char *TAG = "LIGHT_ANIMATION";
 
-/* Motion-strip animation uses LEDs 1..N-1; LED 0 is reserved for Zigbee status. */
-#define STRIP_LED_FIRST_INDEX        1
+#define ANIM_LED_FIRST_INDEX         2
 
 static TaskHandle_t s_animation_task_handle = NULL;
 static EventGroupHandle_t s_wake_events = NULL;
@@ -38,51 +38,56 @@ static void animation_signal_done(void)
     }
 }
 
-/* Returns false if motion cleared during the sweep. */
+static void update_motion_status_led(void)
+{
+    motion_status_led_set(motion_driver_get_state());
+}
+
+static bool animation_time_remaining(int64_t end_us)
+{
+    return esp_timer_get_time() < end_us;
+}
+
 static bool led_active_animation(void)
 {
+    if (CONFIG_EXAMPLE_STRIP_LED_NUMBER <= ANIM_LED_FIRST_INDEX) {
+        return false;
+    }
+
     uint8_t r = 255;
     uint8_t g = 180;
     uint8_t b = 0;
 
-    for (int led = STRIP_LED_FIRST_INDEX; led < CONFIG_EXAMPLE_STRIP_LED_NUMBER; led++) {
-        if (!motion_driver_get_state()) {
-            return false;
-        }
+    for (int led = ANIM_LED_FIRST_INDEX; led < CONFIG_EXAMPLE_STRIP_LED_NUMBER; led++) {
         light_driver_set_pixel(led, r, g, b);
         vTaskDelay(pdMS_TO_TICKS(50));
         light_driver_set_pixel(led, 0, 0, 0);
     }
-    for (int led = CONFIG_EXAMPLE_STRIP_LED_NUMBER - 2; led > STRIP_LED_FIRST_INDEX; led--) {
-        if (!motion_driver_get_state()) {
-            return false;
-        }
+    for (int led = CONFIG_EXAMPLE_STRIP_LED_NUMBER - 2; led >= ANIM_LED_FIRST_INDEX; led--) {
         light_driver_set_pixel(led, r, g, b);
         vTaskDelay(pdMS_TO_TICKS(50));
         light_driver_set_pixel(led, 0, 0, 0);
     }
 
-    light_driver_set_pixel(STRIP_LED_FIRST_INDEX, r, g, b);
+    light_driver_set_pixel(ANIM_LED_FIRST_INDEX, r, g, b);
     return true;
 }
 
 static void led_phase_out_animation(void)
 {
+    if (CONFIG_EXAMPLE_STRIP_LED_NUMBER <= ANIM_LED_FIRST_INDEX) {
+        return;
+    }
+
     uint8_t r = 255;
     uint8_t g = 180;
     uint8_t b = 0;
 
-    for (int led = STRIP_LED_FIRST_INDEX; led < CONFIG_EXAMPLE_STRIP_LED_NUMBER; led++) {
+    for (int led = ANIM_LED_FIRST_INDEX; led < CONFIG_EXAMPLE_STRIP_LED_NUMBER; led++) {
         light_driver_set_pixel(led, r, g, b);
         vTaskDelay(pdMS_TO_TICKS(100));
         light_driver_set_pixel(led, 0, 0, 0);
     }
-}
-
-static void animation_task_end(void)
-{
-    s_animation_task_handle = NULL;
-    vTaskDelete(NULL);
 }
 
 static void animation_task(void *pvParameters)
@@ -91,41 +96,40 @@ static void animation_task(void *pvParameters)
 
     ESP_LOGI(TAG, "Animation task started");
 
-    /* PIR (AM312) needs a moment after GPIO wake before the level is stable. */
-    vTaskDelay(pdMS_TO_TICKS(100));
+    motion_driver_wait_settled();
+    update_motion_status_led();
 
-    if (!motion_driver_get_state()) {
-        ESP_LOGI(TAG, "No motion after settle, animation skipped");
-        animation_signal_done();
-        animation_task_end();
-        return;
-    }
+    const bool motion = motion_driver_get_state_debounced();
+    const bool light_enabled = zigbee_motion_light_enabled();
+    const int64_t end_us = esp_timer_get_time() + (int64_t)LIGHT_ANIMATION_MAX_MS * 1000;
 
-    if (!zigbee_motion_light_enabled()) {
-        ESP_LOGI(TAG, "Light disabled via On/Off, animation skipped");
-        animation_signal_done();
-        animation_task_end();
-        return;
-    }
+    if (!motion || !light_enabled) {
+        ESP_LOGI(TAG, "Main animation skipped (motion=%d, light=%d)", motion, light_enabled);
+    } else {
+        ESP_LOGI(TAG, "Motion detected, running strip animation for %d ms", LIGHT_ANIMATION_MAX_MS);
 
-    ESP_LOGI(TAG, "Motion detected, running strip animation");
+        while (animation_time_remaining(end_us) && zigbee_motion_light_enabled()) {
+            update_motion_status_led();
+            led_active_animation();
+        }
 
-    while (motion_driver_get_state() && zigbee_motion_light_enabled()) {
-        if (!led_active_animation()) {
-            break;
+        for (int led = ANIM_LED_FIRST_INDEX; led < CONFIG_EXAMPLE_STRIP_LED_NUMBER; led++) {
+            light_driver_set_pixel(led, 0, 0, 0);
+        }
+
+        if (!motion_driver_get_state()) {
+            ESP_LOGI(TAG, "Motion cleared, phase out");
+            led_phase_out_animation();
         }
     }
 
-    /* Unblock sleep before cosmetic phase-out (strip may be cut off by deep sleep). */
     animation_signal_done();
 
-    if (!motion_driver_get_state()) {
-        ESP_LOGI(TAG, "Motion cleared, phase out");
-        led_phase_out_animation();
+    /* Keep motion indicator in sync until deep sleep (PIR may clear after occupancy). */
+    while (true) {
+        update_motion_status_led();
+        vTaskDelay(pdMS_TO_TICKS(200));
     }
-
-    ESP_LOGI(TAG, "Animation task finished");
-    animation_task_end();
 }
 
 TaskHandle_t light_animation_init(EventGroupHandle_t wake_events, EventBits_t done_bit)

--- a/zigbee-motion-light/components/light_animation/light_animation.c
+++ b/zigbee-motion-light/components/light_animation/light_animation.c
@@ -16,6 +16,7 @@
 #include "light_animation.h"
 #include "light_driver.h"
 #include "motion_driver.h"
+#include "zigbee_motion.h"
 
 static const char *TAG = "LIGHT_ANIMATION";
 
@@ -100,9 +101,16 @@ static void animation_task(void *pvParameters)
         return;
     }
 
+    if (!zigbee_motion_light_enabled()) {
+        ESP_LOGI(TAG, "Light disabled via On/Off, animation skipped");
+        animation_signal_done();
+        animation_task_end();
+        return;
+    }
+
     ESP_LOGI(TAG, "Motion detected, running strip animation");
 
-    while (motion_driver_get_state()) {
+    while (motion_driver_get_state() && zigbee_motion_light_enabled()) {
         if (!led_active_animation()) {
             break;
         }

--- a/zigbee-motion-light/components/light_animation/light_animation.h
+++ b/zigbee-motion-light/components/light_animation/light_animation.h
@@ -13,6 +13,9 @@
 extern "C" {
 #endif
 
+/** Maximum duration of the main strip animation per wake cycle (ms). */
+#define LIGHT_ANIMATION_MAX_MS  (30 * 1000)
+
 /**
  * @brief Initialize and start the light animation component.
  *

--- a/zigbee-motion-light/components/motion_driver/motion_driver.c
+++ b/zigbee-motion-light/components/motion_driver/motion_driver.c
@@ -47,6 +47,27 @@ bool motion_driver_get_state(void)
     return gpio_get_level(MOTION_SENSOR_GPIO) == (MOTION_DETECTED_HIGH ? 1 : 0);
 }
 
+bool motion_driver_get_state_debounced(void)
+{
+    int active_samples = 0;
+
+    for (int i = 0; i < 5; i++) {
+        if (motion_driver_get_state()) {
+            active_samples++;
+        }
+        if (i + 1 < 5) {
+            vTaskDelay(pdMS_TO_TICKS(40));
+        }
+    }
+
+    return active_samples >= 3;
+}
+
+void motion_driver_wait_settled(void)
+{
+    vTaskDelay(pdMS_TO_TICKS(MOTION_PIR_SETTLE_MS));
+}
+
 bool motion_driver_was_motion_detected(void)
 {
     bool detected = motion_detected_flag;

--- a/zigbee-motion-light/components/motion_driver/motion_driver.h
+++ b/zigbee-motion-light/components/motion_driver/motion_driver.h
@@ -28,6 +28,9 @@ extern "C" {
 #define AM312_RANGE_MAX             5.0     // Maximum detection range (meters)
 #define AM312_FOV                   100     // Field of view (degrees)
 
+/** AM312 stabilization after ESP wake from deep sleep (ms). */
+#define MOTION_PIR_SETTLE_MS        2000
+
 /**
  * @brief Initialize motion sensor driver.
  *
@@ -42,6 +45,16 @@ void motion_driver_init(void);
  * @return true if motion is detected, false otherwise
  */
 bool motion_driver_get_state(void);
+
+/**
+ * @brief Sample the PIR several times; true if a majority read motion active.
+ */
+bool motion_driver_get_state_debounced(void);
+
+/**
+ * @brief Wait for AM312 to stabilize after deep-sleep wake.
+ */
+void motion_driver_wait_settled(void);
 
 /**
  * @brief Check if motion was detected (clears the flag).

--- a/zigbee-motion-light/components/motion_status_led/CMakeLists.txt
+++ b/zigbee-motion-light/components/motion_status_led/CMakeLists.txt
@@ -1,0 +1,5 @@
+idf_component_register(
+    SRCS "motion_status_led.c"
+    INCLUDE_DIRS "."
+    REQUIRES light_driver
+)

--- a/zigbee-motion-light/components/motion_status_led/motion_status_led.c
+++ b/zigbee-motion-light/components/motion_status_led/motion_status_led.c
@@ -1,0 +1,29 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+#include "motion_status_led.h"
+#include "light_driver.h"
+
+#define MOTION_STATUS_LED_INDEX  1
+
+void motion_status_led_init(void)
+{
+    motion_status_led_set(false);
+}
+
+void motion_status_led_off(void)
+{
+    light_driver_set_pixel(MOTION_STATUS_LED_INDEX, 0, 0, 0);
+}
+
+void motion_status_led_set(bool motion_detected)
+{
+    if (motion_detected) {
+        light_driver_set_pixel(MOTION_STATUS_LED_INDEX, 255, 0, 0);
+    } else {
+        light_driver_set_pixel(MOTION_STATUS_LED_INDEX, 0, 255, 0);
+    }
+}

--- a/zigbee-motion-light/components/motion_status_led/motion_status_led.h
+++ b/zigbee-motion-light/components/motion_status_led/motion_status_led.h
@@ -1,0 +1,24 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+#pragma once
+
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** Owns RGB pixel 1 only (motion: green = clear, red = detected). */
+void motion_status_led_init(void);
+
+void motion_status_led_off(void);
+
+void motion_status_led_set(bool motion_detected);
+
+#ifdef __cplusplus
+}
+#endif

--- a/zigbee-motion-light/components/zigbee_motion/CMakeLists.txt
+++ b/zigbee-motion-light/components/zigbee_motion/CMakeLists.txt
@@ -1,6 +1,6 @@
 idf_component_register(
     SRCS "zigbee_motion.c"
     INCLUDE_DIRS "."
-    REQUIRES link_status_led motion_driver
+    REQUIRES link_status_led motion_driver nvs_flash
     PRIV_REQUIRES espressif__esp-zigbee-lib espressif__esp-zboss-lib
 )

--- a/zigbee-motion-light/components/zigbee_motion/zigbee_motion.c
+++ b/zigbee-motion-light/components/zigbee_motion/zigbee_motion.c
@@ -56,6 +56,50 @@ static esp_err_t send_occupancy_to_network(bool occupied, bool dedupe);
 static void flush_pending_occupancy(void);
 static void monitor_task(void *pvParameters);
 static void try_signal_wake_ready(void);
+static bool zigbee_motion_network_is_valid(void);
+static void zigbee_motion_log_nvram_snapshot(const char *context);
+static void zigbee_motion_lock_channel_from_stack(void);
+
+static bool zigbee_motion_network_is_valid(void)
+{
+    if (!esp_zb_bdb_dev_joined()) {
+        return false;
+    }
+
+    uint16_t addr = esp_zb_get_short_address();
+    uint16_t pan = esp_zb_get_pan_id();
+    return addr != 0 && addr != 0xFFFE && addr != 0xFFFF &&
+           pan != 0 && pan != 0xFFFF;
+}
+
+static void zigbee_motion_log_nvram_snapshot(const char *context)
+{
+    esp_zb_ieee_addr_t ext_pan;
+
+    esp_zb_get_extended_pan_id(ext_pan);
+    ESP_LOGI(TAG,
+             "NVRAM snapshot [%s]: factory_new=%d dev_joined=%d valid=%d "
+             "PAN=0x%04hx Ch=%u Addr=0x%04hx ExtPAN=%02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x",
+             context,
+             esp_zb_bdb_is_factory_new(),
+             esp_zb_bdb_dev_joined(),
+             zigbee_motion_network_is_valid(),
+             esp_zb_get_pan_id(),
+             esp_zb_get_current_channel(),
+             esp_zb_get_short_address(),
+             ext_pan[7], ext_pan[6], ext_pan[5], ext_pan[4],
+             ext_pan[3], ext_pan[2], ext_pan[1], ext_pan[0]);
+}
+
+static void zigbee_motion_lock_channel_from_stack(void)
+{
+    uint8_t ch = esp_zb_get_current_channel();
+
+    if (ch >= 11 && ch <= 26) {
+        esp_zb_set_primary_network_channel_set(1 << ch);
+        esp_zb_set_secondary_network_channel_set(0);
+    }
+}
 
 static void try_signal_wake_ready(void)
 {
@@ -195,39 +239,67 @@ void esp_zb_app_signal_handler(esp_zb_app_signal_t *signal_struct)
     case ESP_ZB_BDB_SIGNAL_DEVICE_FIRST_START:
     case ESP_ZB_BDB_SIGNAL_DEVICE_REBOOT:
         if (err_status == ESP_OK) {
+            const char *boot_ctx = (sig_type == ESP_ZB_BDB_SIGNAL_DEVICE_FIRST_START)
+                                       ? "DEVICE_FIRST_START"
+                                       : "DEVICE_REBOOT";
+            zigbee_motion_log_nvram_snapshot(boot_ctx);
             ESP_LOGI(TAG, "Device started up in%s factory-reset mode",
                      esp_zb_bdb_is_factory_new() ? "" : " non");
             if (esp_zb_bdb_is_factory_new()) {
                 ESP_LOGI(TAG, "Start network steering");
                 link_status_led_set_steering();
                 esp_zb_bdb_start_top_level_commissioning(ESP_ZB_BDB_MODE_NETWORK_STEERING);
-            } else {
+            } else if (zigbee_motion_network_is_valid()) {
                 ESP_LOGI(TAG, "Rejoined from NVRAM");
+                zigbee_motion_lock_channel_from_stack();
                 zigbee_motion_mark_joined();
+            } else {
+                ESP_LOGW(TAG, "NVRAM data present but network invalid, falling back to steering");
+                link_status_led_set_steering();
+                esp_zb_bdb_start_top_level_commissioning(ESP_ZB_BDB_MODE_NETWORK_STEERING);
             }
         } else {
-            ESP_LOGW(TAG, "%s failed with status: %s",
-                     esp_zb_zdo_signal_to_string(sig_type), esp_err_to_name(err_status));
-            if (sig_type == ESP_ZB_BDB_SIGNAL_DEVICE_REBOOT && !esp_zb_bdb_is_factory_new()) {
-                ESP_LOGW(TAG, "Silent rejoin failed, falling back to network steering");
-                link_status_led_set_steering();
-                esp_zb_scheduler_alarm((esp_zb_callback_t)bdb_start_top_level_commissioning_cb,
-                                       ESP_ZB_BDB_MODE_NETWORK_STEERING, 1000);
+            zigbee_motion_log_nvram_snapshot(esp_zb_zdo_signal_to_string(sig_type));
+            if (zigbee_motion_network_is_valid()) {
+                ESP_LOGI(TAG, "Rejoined from NVRAM (%s reported %s)",
+                         esp_zb_zdo_signal_to_string(sig_type), esp_err_to_name(err_status));
+                zigbee_motion_lock_channel_from_stack();
+                zigbee_motion_mark_joined();
             } else {
-                esp_zb_scheduler_alarm((esp_zb_callback_t)bdb_start_top_level_commissioning_cb,
-                                       ESP_ZB_BDB_MODE_INITIALIZATION, 1000);
+                ESP_LOGW(TAG, "%s failed with status: %s",
+                         esp_zb_zdo_signal_to_string(sig_type), esp_err_to_name(err_status));
+                if (sig_type == ESP_ZB_BDB_SIGNAL_DEVICE_REBOOT && !esp_zb_bdb_is_factory_new()) {
+                    ESP_LOGW(TAG, "Rejoin in progress, retrying initialization");
+                    esp_zb_scheduler_alarm((esp_zb_callback_t)bdb_start_top_level_commissioning_cb,
+                                           ESP_ZB_BDB_MODE_INITIALIZATION, 1000);
+                } else {
+                    esp_zb_scheduler_alarm((esp_zb_callback_t)bdb_start_top_level_commissioning_cb,
+                                           ESP_ZB_BDB_MODE_INITIALIZATION, 1000);
+                }
             }
         }
         break;
 
     case ESP_ZB_BDB_SIGNAL_STEERING:
-        if (err_status == ESP_OK) {
-            esp_zb_ieee_addr_t extended_pan_id;
-            esp_zb_get_extended_pan_id(extended_pan_id);
+        if (s_joined) {
+            ESP_LOGD(TAG, "Ignoring steering signal, already joined");
+            break;
+        }
+        if (err_status == ESP_OK && zigbee_motion_network_is_valid()) {
+            zigbee_motion_log_nvram_snapshot("STEERING join");
+            zigbee_motion_lock_channel_from_stack();
             ESP_LOGI(TAG, "Joined network (PAN: 0x%04hx, Ch:%d, Addr: 0x%04hx)",
                      esp_zb_get_pan_id(), esp_zb_get_current_channel(),
                      esp_zb_get_short_address());
             zigbee_motion_mark_joined();
+        } else if (err_status == ESP_OK) {
+            zigbee_motion_log_nvram_snapshot("STEERING invalid");
+            ESP_LOGW(TAG, "Steering OK but not on network (PAN: 0x%04hx, Ch:%d, Addr: 0x%04hx, joined=%d)",
+                     esp_zb_get_pan_id(), esp_zb_get_current_channel(),
+                     esp_zb_get_short_address(), esp_zb_bdb_dev_joined());
+            link_status_led_set_steering();
+            esp_zb_scheduler_alarm((esp_zb_callback_t)bdb_start_top_level_commissioning_cb,
+                                   ESP_ZB_BDB_MODE_NETWORK_STEERING, 1000);
         } else {
             ESP_LOGW(TAG, "Network steering failed: %s", esp_err_to_name(err_status));
             link_status_led_set_steering();

--- a/zigbee-motion-light/components/zigbee_motion/zigbee_motion.c
+++ b/zigbee-motion-light/components/zigbee_motion/zigbee_motion.c
@@ -11,11 +11,15 @@
 
 #include "esp_log.h"
 #include "esp_check.h"
+#include "nvs.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 #include "freertos/event_groups.h"
 #include "esp_zigbee_core.h"
+#include "esp_zigbee_attribute.h"
+#include "nwk/esp_zigbee_nwk.h"
 #include "ha/esp_zigbee_ha_standard.h"
+#include "zcl/esp_zigbee_zcl_command.h"
 #include "zigbee_motion.h"
 #include "link_status_led.h"
 #include "motion_driver.h"
@@ -36,6 +40,17 @@ static const char *TAG = "ZIGBEE_MOTION";
 #define ESP_MANUFACTURER_NAME   "\x09""ESPRESSIF"
 #define ESP_MODEL_IDENTIFIER    "\x0D""Motion-Light"
 
+#define COORDINATOR_ADDR         0x0000
+#define COORDINATOR_ENDPOINT     1
+#define OCC_REPORT_TIMEOUT_MS    (60 * 1000)
+#define ZCL_CMD_REPORT_ATTRIBUTES 0x0a
+
+#define OCC_REPORT_ACK_BIT  BIT0
+#define OCC_REPORT_FAIL_BIT BIT1
+
+#define ON_OFF_NVS_NAMESPACE  "motion_lt"
+#define ON_OFF_NVS_KEY        "on_off"
+
 /* Occupancy cluster reference */
 static esp_zb_attribute_list_t *s_occupancy_cluster = NULL;
 
@@ -45,13 +60,21 @@ static bool s_last_occupancy_state = false;
 static bool s_joined;
 static bool s_pending_valid;
 static bool s_pending_occupied;
-static bool s_zigbee_finished = false;
 static TaskHandle_t s_zigbee_task_handle = NULL;
 static TaskHandle_t s_monitor_task_handle = NULL;
-static bool s_motion_prev = false;
 static EventGroupHandle_t s_wake_events = NULL;
 static EventBits_t s_ready_bit = 0;
+static EventGroupHandle_t s_report_events = NULL;
+static volatile bool s_report_waiting = false;
+static volatile bool s_report_aps_ok = false;
+static bool s_report_payload_occupied;
+static TickType_t s_radio_hold_deadline_tick;
+static bool s_light_enabled = true;
 
+static void zigbee_motion_arm_radio_hold_ms(uint32_t ms);
+static void zigbee_motion_sync_rx_hold_cb(uint8_t unused);
+static void zigbee_motion_mark_left(void);
+static void zigbee_motion_note_coordinator_activity(void);
 static esp_err_t send_occupancy_to_network(bool occupied, bool dedupe);
 static void flush_pending_occupancy(void);
 static void monitor_task(void *pvParameters);
@@ -59,6 +82,106 @@ static void try_signal_wake_ready(void);
 static bool zigbee_motion_network_is_valid(void);
 static void zigbee_motion_log_nvram_snapshot(const char *context);
 static void zigbee_motion_lock_channel_from_stack(void);
+static void zigbee_motion_load_on_off_from_nvs(void);
+static void zigbee_motion_save_on_off_to_nvs(bool enabled);
+static void zigbee_motion_apply_on_off(bool enabled);
+static void zigbee_motion_sync_on_off_from_stack(void);
+static esp_err_t zigbee_motion_on_off_attr_handler(const esp_zb_zcl_set_attr_value_message_t *message);
+
+static void occupancy_report_complete(bool success)
+{
+    if (!s_report_waiting || s_report_events == NULL) {
+        return;
+    }
+
+    s_report_waiting = false;
+    xEventGroupSetBits(s_report_events, success ? OCC_REPORT_ACK_BIT : OCC_REPORT_FAIL_BIT);
+}
+
+static void occupancy_command_send_status_cb(esp_zb_zcl_command_send_status_message_t message)
+{
+    if (!s_report_waiting) {
+        return;
+    }
+
+    if (message.src_endpoint != MOTION_LIGHT_ENDPOINT ||
+        message.dst_endpoint != COORDINATOR_ENDPOINT ||
+        message.dst_addr.u.short_addr != COORDINATOR_ADDR) {
+        return;
+    }
+
+    if (message.status == ESP_OK) {
+        s_report_aps_ok = true;
+        return;
+    }
+
+    ESP_LOGW(TAG, "Occupancy report APS send failed: %s", esp_err_to_name(message.status));
+    occupancy_report_complete(false);
+}
+
+static esp_err_t wait_for_occupancy_report_response(void)
+{
+    EventBits_t bits = xEventGroupWaitBits(s_report_events,
+                                           OCC_REPORT_ACK_BIT | OCC_REPORT_FAIL_BIT,
+                                           pdTRUE,
+                                           pdFALSE,
+                                           pdMS_TO_TICKS(OCC_REPORT_TIMEOUT_MS));
+
+    if (bits & OCC_REPORT_ACK_BIT) {
+        ESP_LOGI(TAG, "Occupancy report acknowledged by coordinator");
+        return ESP_OK;
+    }
+
+    if (bits & OCC_REPORT_FAIL_BIT) {
+        ESP_LOGW(TAG, "Occupancy report rejected or failed");
+        return ESP_FAIL;
+    }
+
+    s_report_waiting = false;
+    if (s_report_aps_ok) {
+        ESP_LOGW(TAG, "No default response within %d ms; accepting APS send OK",
+                 OCC_REPORT_TIMEOUT_MS);
+        return ESP_OK;
+    }
+
+    ESP_LOGW(TAG, "Occupancy report response timeout (%d ms)", OCC_REPORT_TIMEOUT_MS);
+    return ESP_ERR_TIMEOUT;
+}
+
+static void occupancy_report_issue_cb(uint8_t param)
+{
+    (void)param;
+
+    uint8_t occupancy_value = s_report_payload_occupied ? 1 : 0;
+    esp_zb_zcl_status_t attr_status = esp_zb_zcl_set_attribute_val(
+        MOTION_LIGHT_ENDPOINT,
+        ESP_ZB_ZCL_CLUSTER_ID_OCCUPANCY_SENSING,
+        ESP_ZB_ZCL_CLUSTER_SERVER_ROLE,
+        ESP_ZB_ZCL_ATTR_OCCUPANCY_SENSING_OCCUPANCY_ID,
+        &occupancy_value, false);
+    if (attr_status != ESP_ZB_ZCL_STATUS_SUCCESS) {
+        ESP_LOGW(TAG, "Set occupancy attribute failed: 0x%02x", attr_status);
+        occupancy_report_complete(false);
+        return;
+    }
+
+    esp_zb_zcl_report_attr_cmd_t report_cmd = {
+        .zcl_basic_cmd = {
+            .dst_addr_u.addr_short = COORDINATOR_ADDR,
+            .dst_endpoint = COORDINATOR_ENDPOINT,
+            .src_endpoint = MOTION_LIGHT_ENDPOINT,
+        },
+        .address_mode = ESP_ZB_APS_ADDR_MODE_16_ENDP_PRESENT,
+        .direction = ESP_ZB_ZCL_CMD_DIRECTION_TO_CLI,
+        .clusterID = ESP_ZB_ZCL_CLUSTER_ID_OCCUPANCY_SENSING,
+        .attributeID = ESP_ZB_ZCL_ATTR_OCCUPANCY_SENSING_OCCUPANCY_ID,
+    };
+    esp_err_t ret = esp_zb_zcl_report_attr_cmd_req(&report_cmd);
+    if (ret != ESP_OK) {
+        ESP_LOGW(TAG, "Occupancy report request failed: %s", esp_err_to_name(ret));
+        occupancy_report_complete(false);
+    }
+}
 
 static bool zigbee_motion_network_is_valid(void)
 {
@@ -101,9 +224,133 @@ static void zigbee_motion_lock_channel_from_stack(void)
     }
 }
 
+static void zigbee_motion_load_on_off_from_nvs(void)
+{
+    nvs_handle_t handle;
+    if (nvs_open(ON_OFF_NVS_NAMESPACE, NVS_READONLY, &handle) != ESP_OK) {
+        return;
+    }
+
+    uint8_t stored = 1;
+    if (nvs_get_u8(handle, ON_OFF_NVS_KEY, &stored) == ESP_OK) {
+        s_light_enabled = (stored != 0);
+        ESP_LOGI(TAG, "On/Off state from NVS: %s", s_light_enabled ? "ON" : "OFF");
+    }
+    nvs_close(handle);
+}
+
+static void zigbee_motion_save_on_off_to_nvs(bool enabled)
+{
+    nvs_handle_t handle;
+    if (nvs_open(ON_OFF_NVS_NAMESPACE, NVS_READWRITE, &handle) != ESP_OK) {
+        ESP_LOGW(TAG, "Failed to open NVS for On/Off state");
+        return;
+    }
+
+    esp_err_t err = nvs_set_u8(handle, ON_OFF_NVS_KEY, enabled ? 1 : 0);
+    if (err == ESP_OK) {
+        err = nvs_commit(handle);
+    }
+    if (err != ESP_OK) {
+        ESP_LOGW(TAG, "Failed to persist On/Off state: %s", esp_err_to_name(err));
+    }
+    nvs_close(handle);
+}
+
+static void zigbee_motion_apply_on_off(bool enabled)
+{
+    if (s_light_enabled == enabled) {
+        return;
+    }
+
+    s_light_enabled = enabled;
+    zigbee_motion_save_on_off_to_nvs(enabled);
+    ESP_LOGI(TAG, "Light %s via On/Off cluster", enabled ? "enabled" : "disabled");
+}
+
+static void zigbee_motion_sync_on_off_from_stack(void)
+{
+    esp_zb_zcl_attr_t *attr = esp_zb_zcl_get_attribute(
+        MOTION_LIGHT_ENDPOINT,
+        ESP_ZB_ZCL_CLUSTER_ID_ON_OFF,
+        ESP_ZB_ZCL_CLUSTER_SERVER_ROLE,
+        ESP_ZB_ZCL_ATTR_ON_OFF_ON_OFF_ID);
+    if (attr == NULL || attr->data_p == NULL) {
+        return;
+    }
+
+    bool enabled = *(bool *)attr->data_p;
+    s_light_enabled = enabled;
+    zigbee_motion_save_on_off_to_nvs(enabled);
+    ESP_LOGI(TAG, "On/Off state from stack: %s", enabled ? "ON" : "OFF");
+}
+
+static esp_err_t zigbee_motion_on_off_attr_handler(const esp_zb_zcl_set_attr_value_message_t *message)
+{
+    if (message->info.dst_endpoint != MOTION_LIGHT_ENDPOINT ||
+        message->info.cluster != ESP_ZB_ZCL_CLUSTER_ID_ON_OFF ||
+        message->info.status != ESP_ZB_ZCL_STATUS_SUCCESS) {
+        return ESP_OK;
+    }
+
+    if (message->attribute.id == ESP_ZB_ZCL_ATTR_ON_OFF_ON_OFF_ID &&
+        message->attribute.data.type == ESP_ZB_ZCL_ATTR_TYPE_BOOL) {
+        bool enabled = message->attribute.data.value ? *(bool *)message->attribute.data.value : false;
+        ESP_LOGI(TAG, "Coordinator wrote On/Off: %s", enabled ? "ON" : "OFF");
+        zigbee_motion_apply_on_off(enabled);
+    }
+
+    return ESP_OK;
+}
+
+static void zigbee_motion_sync_rx_hold_cb(uint8_t unused)
+{
+    (void)unused;
+    esp_zb_set_rx_on_when_idle(zigbee_motion_radio_hold_remaining_ms() > 0);
+}
+
+static void zigbee_motion_arm_radio_hold_ms(uint32_t ms)
+{
+    TickType_t now = xTaskGetTickCount();
+    TickType_t deadline = now + pdMS_TO_TICKS(ms);
+
+    if (s_radio_hold_deadline_tick == 0 ||
+        (int32_t)(deadline - s_radio_hold_deadline_tick) > 0) {
+        s_radio_hold_deadline_tick = deadline;
+        esp_zb_scheduler_alarm((esp_zb_callback_t)zigbee_motion_sync_rx_hold_cb, 0, 0);
+    }
+}
+
+static void zigbee_motion_note_coordinator_activity(void)
+{
+    if (s_joined) {
+        zigbee_motion_arm_radio_hold_ms(ZIGBEE_MOTION_INTERVIEW_EXTEND_MS);
+    }
+}
+
+static void zigbee_motion_mark_left(void)
+{
+    s_joined = false;
+    s_pending_valid = false;
+    s_report_waiting = false;
+
+    if (s_monitor_task_handle != NULL) {
+        vTaskDelete(s_monitor_task_handle);
+        s_monitor_task_handle = NULL;
+    }
+
+    link_status_led_set_steering();
+
+    if (s_wake_events != NULL) {
+        xEventGroupSetBits(s_wake_events, s_ready_bit);
+        ESP_LOGI(TAG, "Supervisor released after leave (bits 0x%lx)",
+                 (unsigned long)xEventGroupGetBits(s_wake_events));
+    }
+}
+
 static void try_signal_wake_ready(void)
 {
-    if (s_wake_events != NULL && s_joined && !s_pending_valid && s_zigbee_finished) {
+    if (s_wake_events != NULL && s_joined && !s_pending_valid && !s_report_waiting) {
         xEventGroupSetBits(s_wake_events, s_ready_bit);
         ESP_LOGI(TAG, "Zigbee track ready (bits 0x%lx)",
                  (unsigned long)xEventGroupGetBits(s_wake_events));
@@ -118,6 +365,7 @@ static void zigbee_motion_mark_joined(void)
     }
     s_joined = true;
     link_status_led_set_joined();
+    zigbee_motion_sync_on_off_from_stack();
     flush_pending_occupancy();
 
     /* Create monitor task after joining */
@@ -150,42 +398,18 @@ static void monitor_task(void *pvParameters)
 
     ESP_LOGI(TAG, "Monitor task started");
 
-    s_motion_prev = motion_driver_get_state();
-    ESP_LOGI(TAG, "Initial motion state: %s", s_motion_prev ? "DETECTED" : "CLEARED");
-
-    if (s_motion_prev) {
-        send_occupancy_to_network(true, true);
-    }
-
-    /* If motion is already false, send report and finish immediately */
-    if (!s_motion_prev) {
-        ESP_LOGI(TAG, "Motion already cleared, sending report and finishing");
-        send_occupancy_to_network(false, true);
-        s_zigbee_finished = true;
-        try_signal_wake_ready();
-        ESP_LOGI(TAG, "Monitor task finished (motion never detected)");
-        vTaskDelete(NULL);
-        return;
-    }
+    vTaskDelay(pdMS_TO_TICKS(100));
 
     for (;;) {
-        bool motion_current = motion_driver_get_state();
-        
-        if (motion_current != s_motion_prev) {
-            s_motion_prev = motion_current;
-            ESP_LOGI(TAG, "Motion state changed: %s", motion_current ? "DETECTED" : "CLEARED");
-            
-            send_occupancy_to_network(motion_current, true);
-            
-            if (!motion_current) {
-                ESP_LOGI(TAG, "Motion cleared, setting zigbee finished flag");
-                s_zigbee_finished = true;
-                try_signal_wake_ready();
-                break;
-            }
+        bool motion = motion_driver_get_state();
+        ESP_LOGI(TAG, "Publishing occupancy (%s)", motion ? "OCCUPIED" : "UNOCCUPIED");
+
+        if (send_occupancy_to_network(motion, false) == ESP_OK) {
+            break;
         }
 
-        vTaskDelay(pdMS_TO_TICKS(100));
+        ESP_LOGW(TAG, "Occupancy report failed, retrying in 1 s");
+        vTaskDelay(pdMS_TO_TICKS(1000));
     }
 
     ESP_LOGI(TAG, "Monitor task finished");
@@ -198,20 +422,33 @@ static esp_err_t send_occupancy_to_network(bool occupied, bool dedupe)
         return ESP_OK;
     }
 
+    if (!s_joined || s_report_events == NULL) {
+        return ESP_ERR_INVALID_STATE;
+    }
+
+    esp_err_t ret;
+
     link_status_led_notify_occupancy_issued();
 
-    uint8_t occupancy_value = occupied ? 1 : 0;
+    xEventGroupClearBits(s_report_events, OCC_REPORT_ACK_BIT | OCC_REPORT_FAIL_BIT);
+    s_report_aps_ok = false;
+    s_report_waiting = true;
+    s_report_payload_occupied = occupied;
+
     esp_zb_lock_acquire(portMAX_DELAY);
-    esp_zb_zcl_set_attribute_val(MOTION_LIGHT_ENDPOINT,
-                                 ESP_ZB_ZCL_CLUSTER_ID_OCCUPANCY_SENSING,
-                                 ESP_ZB_ZCL_CLUSTER_SERVER_ROLE,
-                                 ESP_ZB_ZCL_ATTR_OCCUPANCY_SENSING_OCCUPANCY_ID,
-                                 &occupancy_value, false);
+    esp_zb_scheduler_alarm((esp_zb_callback_t)occupancy_report_issue_cb, 0, 0);
     esp_zb_lock_release();
 
-    s_last_occupancy_state = occupied;
-    ESP_LOGI(TAG, "Updated occupancy attribute: %s", occupied ? "OCCUPIED" : "UNOCCUPIED");
+    ESP_LOGI(TAG, "Occupancy report queued (%s), waiting for response",
+             occupied ? "OCCUPIED" : "UNOCCUPIED");
 
+    ret = wait_for_occupancy_report_response();
+    if (ret != ESP_OK) {
+        return ret;
+    }
+
+    s_last_occupancy_state = occupied;
+    try_signal_wake_ready();
     return ESP_OK;
 }
 
@@ -246,6 +483,7 @@ void esp_zb_app_signal_handler(esp_zb_app_signal_t *signal_struct)
             ESP_LOGI(TAG, "Device started up in%s factory-reset mode",
                      esp_zb_bdb_is_factory_new() ? "" : " non");
             if (esp_zb_bdb_is_factory_new()) {
+                zigbee_motion_arm_radio_hold_ms(ZIGBEE_MOTION_REPAIR_HOLD_MS);
                 ESP_LOGI(TAG, "Start network steering");
                 link_status_led_set_steering();
                 esp_zb_bdb_start_top_level_commissioning(ESP_ZB_BDB_MODE_NETWORK_STEERING);
@@ -280,6 +518,26 @@ void esp_zb_app_signal_handler(esp_zb_app_signal_t *signal_struct)
         }
         break;
 
+    case ESP_ZB_ZDO_SIGNAL_LEAVE:
+        if (err_status == ESP_OK && s_joined) {
+            esp_zb_zdo_signal_leave_params_t *leave_params =
+                (esp_zb_zdo_signal_leave_params_t *)esp_zb_app_signal_get_params(p_sg_p);
+            if (leave_params != NULL) {
+                ESP_LOGI(TAG, "ZDO Leave received (type=%u)", leave_params->leave_type);
+            } else {
+                ESP_LOGI(TAG, "ZDO Leave received");
+            }
+            zigbee_motion_mark_left();
+            zigbee_motion_arm_radio_hold_ms(ZIGBEE_MOTION_REPAIR_HOLD_MS);
+            esp_zb_scheduler_alarm((esp_zb_callback_t)bdb_start_top_level_commissioning_cb,
+                                   ESP_ZB_BDB_MODE_NETWORK_STEERING, 1000);
+        } else if (err_status == ESP_OK) {
+            ESP_LOGD(TAG, "ZDO Leave during stack cleanup (ignored)");
+        } else {
+            ESP_LOGW(TAG, "ZDO Leave failed: %s", esp_err_to_name(err_status));
+        }
+        break;
+
     case ESP_ZB_BDB_SIGNAL_STEERING:
         if (s_joined) {
             ESP_LOGD(TAG, "Ignoring steering signal, already joined");
@@ -308,6 +566,10 @@ void esp_zb_app_signal_handler(esp_zb_app_signal_t *signal_struct)
         }
         break;
 
+    case ESP_ZB_COMMON_SIGNAL_CAN_SLEEP:
+        /* Deep sleep reboot replaces stack sleep; nothing to do. */
+        break;
+
     default:
         ESP_LOGI(TAG, "ZDO signal: %s (0x%x), status: %s",
                  esp_zb_zdo_signal_to_string(sig_type), sig_type,
@@ -318,8 +580,35 @@ void esp_zb_app_signal_handler(esp_zb_app_signal_t *signal_struct)
 
 static esp_err_t zb_action_handler(esp_zb_core_action_callback_id_t callback_id, const void *message)
 {
-    (void)callback_id;
-    (void)message;
+    zigbee_motion_note_coordinator_activity();
+
+    switch (callback_id) {
+    case ESP_ZB_CORE_SET_ATTR_VALUE_CB_ID:
+        if (message != NULL) {
+            zigbee_motion_on_off_attr_handler((const esp_zb_zcl_set_attr_value_message_t *)message);
+        }
+        break;
+    case ESP_ZB_CORE_CMD_DEFAULT_RESP_CB_ID:
+        if (message != NULL) {
+            const esp_zb_zcl_cmd_default_resp_message_t *resp = message;
+
+            if (s_report_waiting &&
+                resp->info.cluster == ESP_ZB_ZCL_CLUSTER_ID_OCCUPANCY_SENSING &&
+                resp->resp_to_cmd == ZCL_CMD_REPORT_ATTRIBUTES) {
+                if (resp->status_code == ESP_ZB_ZCL_STATUS_SUCCESS) {
+                    occupancy_report_complete(true);
+                } else {
+                    ESP_LOGW(TAG, "Occupancy report default response status: 0x%02x",
+                             resp->status_code);
+                    occupancy_report_complete(false);
+                }
+            }
+        }
+        break;
+    default:
+        break;
+    }
+
     return ESP_OK;
 }
 
@@ -344,17 +633,20 @@ static void esp_zb_task(void *pvParameters)
     esp_zb_basic_cluster_add_attr(basic_cluster, ESP_ZB_ZCL_ATTR_BASIC_MODEL_IDENTIFIER_ID,
                                    (void *)ESP_MODEL_IDENTIFIER);
     esp_zb_cluster_list_add_basic_cluster(cluster_list, basic_cluster, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE);
+    esp_zb_cluster_list_add_basic_cluster(cluster_list, esp_zb_basic_cluster_create(NULL),
+                                          ESP_ZB_ZCL_CLUSTER_CLIENT_ROLE);
 
     /* Identify cluster */
     esp_zb_identify_cluster_cfg_t identify_cfg = { .identify_time = 0 };
     esp_zb_attribute_list_t *identify_cluster = esp_zb_identify_cluster_create(&identify_cfg);
     esp_zb_cluster_list_add_identify_cluster(cluster_list, identify_cluster, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE);
 
-    /* On/Off cluster (server) - so the device appears as a light in the Zigbee network */
-    esp_zb_on_off_cluster_cfg_t on_off_cfg = { .on_off = false };
+    /* On/Off cluster (server) — coordinator can disable motion LED strip */
+    esp_zb_on_off_cluster_cfg_t on_off_cfg = {
+        .on_off = s_light_enabled,
+    };
     esp_zb_attribute_list_t *on_off_cluster = esp_zb_on_off_cluster_create(&on_off_cfg);
     esp_zb_cluster_list_add_on_off_cluster(cluster_list, on_off_cluster, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE);
-
 
     /* Occupancy Sensing cluster (server role) - to report motion state */
     esp_zb_occupancy_sensing_cluster_cfg_t occupancy_cfg = {
@@ -362,6 +654,8 @@ static void esp_zb_task(void *pvParameters)
     };
     s_occupancy_cluster = esp_zb_occupancy_sensing_cluster_create(&occupancy_cfg);
     esp_zb_cluster_list_add_occupancy_sensing_cluster(cluster_list, s_occupancy_cluster, ESP_ZB_ZCL_CLUSTER_SERVER_ROLE);
+    esp_zb_cluster_list_add_occupancy_sensing_cluster(
+        cluster_list, esp_zb_occupancy_sensing_cluster_create(&occupancy_cfg), ESP_ZB_ZCL_CLUSTER_CLIENT_ROLE);
 
     /* Create endpoint */
     esp_zb_ep_list_t *ep_list = esp_zb_ep_list_create();
@@ -375,6 +669,9 @@ static void esp_zb_task(void *pvParameters)
 
     esp_zb_device_register(ep_list);
     esp_zb_core_action_handler_register(zb_action_handler);
+    esp_zb_zcl_command_send_status_handler_register(occupancy_command_send_status_cb);
+    esp_zb_set_rx_on_when_idle(false);
+    esp_zb_sleep_enable(false);
     esp_zb_set_primary_network_channel_set(1 << ESP_ZB_PRIMARY_CHANNEL);
 
     ESP_ERROR_CHECK(esp_zb_start(false));
@@ -389,12 +686,20 @@ TaskHandle_t zigbee_motion_init(EventGroupHandle_t wake_events, EventBits_t read
 
     s_wake_events = wake_events;
     s_ready_bit = ready_bit;
+    s_report_events = xEventGroupCreate();
+    if (s_report_events == NULL) {
+        ESP_LOGE(TAG, "Failed to create report event group");
+        return NULL;
+    }
     s_joined = false;
     s_pending_valid = false;
     s_pending_occupied = false;
     s_last_occupancy_state = false;
-    s_zigbee_finished = false;
-    s_motion_prev = false;
+    s_report_waiting = false;
+    s_report_aps_ok = false;
+    s_radio_hold_deadline_tick = 0;
+    s_light_enabled = true;
+    zigbee_motion_load_on_off_from_nvs();
 
     /* Configure Zigbee platform */
     esp_zb_platform_config_t config = {
@@ -445,13 +750,46 @@ bool zigbee_motion_is_joined(void)
     return s_joined;
 }
 
-bool zigbee_motion_occupancy_intent_pending(void)
+bool zigbee_motion_light_enabled(void)
 {
-    return s_pending_valid;
+    return s_light_enabled;
 }
 
-bool zigbee_motion_is_finished(void)
+bool zigbee_motion_occupancy_intent_pending(void)
 {
-    return s_zigbee_finished;
+    return s_pending_valid || s_report_waiting;
+}
+
+uint32_t zigbee_motion_radio_hold_remaining_ms(void)
+{
+    if (s_radio_hold_deadline_tick == 0) {
+        return 0;
+    }
+
+    TickType_t now = xTaskGetTickCount();
+    if ((int32_t)(s_radio_hold_deadline_tick - now) <= 0) {
+        s_radio_hold_deadline_tick = 0;
+        return 0;
+    }
+
+    return (uint32_t)((s_radio_hold_deadline_tick - now) * portTICK_PERIOD_MS);
+}
+
+void zigbee_motion_wait_radio_hold(void)
+{
+    uint32_t remaining_ms = zigbee_motion_radio_hold_remaining_ms();
+    if (remaining_ms == 0) {
+        return;
+    }
+
+    ESP_LOGI(TAG, "Keeping radio up for leave/interview (%lu ms)", (unsigned long)remaining_ms);
+    while ((remaining_ms = zigbee_motion_radio_hold_remaining_ms()) > 0) {
+        uint32_t slice_ms = remaining_ms > 1000 ? 1000 : remaining_ms;
+        vTaskDelay(pdMS_TO_TICKS(slice_ms));
+    }
+    esp_zb_lock_acquire(portMAX_DELAY);
+    esp_zb_set_rx_on_when_idle(false);
+    esp_zb_lock_release();
+    ESP_LOGI(TAG, "Radio hold window closed");
 }
 

--- a/zigbee-motion-light/components/zigbee_motion/zigbee_motion.c
+++ b/zigbee-motion-light/components/zigbee_motion/zigbee_motion.c
@@ -42,11 +42,6 @@ static const char *TAG = "ZIGBEE_MOTION";
 
 #define COORDINATOR_ADDR         0x0000
 #define COORDINATOR_ENDPOINT     1
-#define OCC_REPORT_TIMEOUT_MS    (60 * 1000)
-#define ZCL_CMD_REPORT_ATTRIBUTES 0x0a
-
-#define OCC_REPORT_ACK_BIT  BIT0
-#define OCC_REPORT_FAIL_BIT BIT1
 
 #define ON_OFF_NVS_NAMESPACE  "motion_lt"
 #define ON_OFF_NVS_KEY        "on_off"
@@ -64,17 +59,10 @@ static TaskHandle_t s_zigbee_task_handle = NULL;
 static TaskHandle_t s_monitor_task_handle = NULL;
 static EventGroupHandle_t s_wake_events = NULL;
 static EventBits_t s_ready_bit = 0;
-static EventGroupHandle_t s_report_events = NULL;
-static volatile bool s_report_waiting = false;
-static volatile bool s_report_aps_ok = false;
 static bool s_report_payload_occupied;
-static TickType_t s_radio_hold_deadline_tick;
 static bool s_light_enabled = true;
 
-static void zigbee_motion_arm_radio_hold_ms(uint32_t ms);
-static void zigbee_motion_sync_rx_hold_cb(uint8_t unused);
 static void zigbee_motion_mark_left(void);
-static void zigbee_motion_note_coordinator_activity(void);
 static esp_err_t send_occupancy_to_network(bool occupied, bool dedupe);
 static void flush_pending_occupancy(void);
 static void monitor_task(void *pvParameters);
@@ -87,66 +75,6 @@ static void zigbee_motion_save_on_off_to_nvs(bool enabled);
 static void zigbee_motion_apply_on_off(bool enabled);
 static void zigbee_motion_sync_on_off_from_stack(void);
 static esp_err_t zigbee_motion_on_off_attr_handler(const esp_zb_zcl_set_attr_value_message_t *message);
-
-static void occupancy_report_complete(bool success)
-{
-    if (!s_report_waiting || s_report_events == NULL) {
-        return;
-    }
-
-    s_report_waiting = false;
-    xEventGroupSetBits(s_report_events, success ? OCC_REPORT_ACK_BIT : OCC_REPORT_FAIL_BIT);
-}
-
-static void occupancy_command_send_status_cb(esp_zb_zcl_command_send_status_message_t message)
-{
-    if (!s_report_waiting) {
-        return;
-    }
-
-    if (message.src_endpoint != MOTION_LIGHT_ENDPOINT ||
-        message.dst_endpoint != COORDINATOR_ENDPOINT ||
-        message.dst_addr.u.short_addr != COORDINATOR_ADDR) {
-        return;
-    }
-
-    if (message.status == ESP_OK) {
-        s_report_aps_ok = true;
-        return;
-    }
-
-    ESP_LOGW(TAG, "Occupancy report APS send failed: %s", esp_err_to_name(message.status));
-    occupancy_report_complete(false);
-}
-
-static esp_err_t wait_for_occupancy_report_response(void)
-{
-    EventBits_t bits = xEventGroupWaitBits(s_report_events,
-                                           OCC_REPORT_ACK_BIT | OCC_REPORT_FAIL_BIT,
-                                           pdTRUE,
-                                           pdFALSE,
-                                           pdMS_TO_TICKS(OCC_REPORT_TIMEOUT_MS));
-
-    if (bits & OCC_REPORT_ACK_BIT) {
-        ESP_LOGI(TAG, "Occupancy report acknowledged by coordinator");
-        return ESP_OK;
-    }
-
-    if (bits & OCC_REPORT_FAIL_BIT) {
-        ESP_LOGW(TAG, "Occupancy report rejected or failed");
-        return ESP_FAIL;
-    }
-
-    s_report_waiting = false;
-    if (s_report_aps_ok) {
-        ESP_LOGW(TAG, "No default response within %d ms; accepting APS send OK",
-                 OCC_REPORT_TIMEOUT_MS);
-        return ESP_OK;
-    }
-
-    ESP_LOGW(TAG, "Occupancy report response timeout (%d ms)", OCC_REPORT_TIMEOUT_MS);
-    return ESP_ERR_TIMEOUT;
-}
 
 static void occupancy_report_issue_cb(uint8_t param)
 {
@@ -161,7 +89,7 @@ static void occupancy_report_issue_cb(uint8_t param)
         &occupancy_value, false);
     if (attr_status != ESP_ZB_ZCL_STATUS_SUCCESS) {
         ESP_LOGW(TAG, "Set occupancy attribute failed: 0x%02x", attr_status);
-        occupancy_report_complete(false);
+        try_signal_wake_ready();
         return;
     }
 
@@ -179,8 +107,9 @@ static void occupancy_report_issue_cb(uint8_t param)
     esp_err_t ret = esp_zb_zcl_report_attr_cmd_req(&report_cmd);
     if (ret != ESP_OK) {
         ESP_LOGW(TAG, "Occupancy report request failed: %s", esp_err_to_name(ret));
-        occupancy_report_complete(false);
     }
+
+    try_signal_wake_ready();
 }
 
 static bool zigbee_motion_network_is_valid(void)
@@ -303,36 +232,10 @@ static esp_err_t zigbee_motion_on_off_attr_handler(const esp_zb_zcl_set_attr_val
     return ESP_OK;
 }
 
-static void zigbee_motion_sync_rx_hold_cb(uint8_t unused)
-{
-    (void)unused;
-    esp_zb_set_rx_on_when_idle(zigbee_motion_radio_hold_remaining_ms() > 0);
-}
-
-static void zigbee_motion_arm_radio_hold_ms(uint32_t ms)
-{
-    TickType_t now = xTaskGetTickCount();
-    TickType_t deadline = now + pdMS_TO_TICKS(ms);
-
-    if (s_radio_hold_deadline_tick == 0 ||
-        (int32_t)(deadline - s_radio_hold_deadline_tick) > 0) {
-        s_radio_hold_deadline_tick = deadline;
-        esp_zb_scheduler_alarm((esp_zb_callback_t)zigbee_motion_sync_rx_hold_cb, 0, 0);
-    }
-}
-
-static void zigbee_motion_note_coordinator_activity(void)
-{
-    if (s_joined) {
-        zigbee_motion_arm_radio_hold_ms(ZIGBEE_MOTION_INTERVIEW_EXTEND_MS);
-    }
-}
-
 static void zigbee_motion_mark_left(void)
 {
     s_joined = false;
     s_pending_valid = false;
-    s_report_waiting = false;
 
     if (s_monitor_task_handle != NULL) {
         vTaskDelete(s_monitor_task_handle);
@@ -350,7 +253,7 @@ static void zigbee_motion_mark_left(void)
 
 static void try_signal_wake_ready(void)
 {
-    if (s_wake_events != NULL && s_joined && !s_pending_valid && !s_report_waiting) {
+    if (s_wake_events != NULL && s_joined && !s_pending_valid) {
         xEventGroupSetBits(s_wake_events, s_ready_bit);
         ESP_LOGI(TAG, "Zigbee track ready (bits 0x%lx)",
                  (unsigned long)xEventGroupGetBits(s_wake_events));
@@ -386,7 +289,6 @@ static void flush_pending_occupancy(void)
     esp_err_t r = send_occupancy_to_network(occ, true);
     if (r == ESP_OK) {
         s_pending_valid = false;
-        try_signal_wake_ready();
         return;
     }
     ESP_LOGW(TAG, "flush pending occupancy failed, keeping intent for retry");
@@ -419,36 +321,25 @@ static void monitor_task(void *pvParameters)
 static esp_err_t send_occupancy_to_network(bool occupied, bool dedupe)
 {
     if (dedupe && s_last_occupancy_state == occupied) {
+        try_signal_wake_ready();
         return ESP_OK;
     }
 
-    if (!s_joined || s_report_events == NULL) {
+    if (!s_joined) {
         return ESP_ERR_INVALID_STATE;
     }
 
-    esp_err_t ret;
-
     link_status_led_notify_occupancy_issued();
-
-    xEventGroupClearBits(s_report_events, OCC_REPORT_ACK_BIT | OCC_REPORT_FAIL_BIT);
-    s_report_aps_ok = false;
-    s_report_waiting = true;
     s_report_payload_occupied = occupied;
 
     esp_zb_lock_acquire(portMAX_DELAY);
     esp_zb_scheduler_alarm((esp_zb_callback_t)occupancy_report_issue_cb, 0, 0);
     esp_zb_lock_release();
 
-    ESP_LOGI(TAG, "Occupancy report queued (%s), waiting for response",
+    ESP_LOGI(TAG, "Occupancy report queued (%s)",
              occupied ? "OCCUPIED" : "UNOCCUPIED");
 
-    ret = wait_for_occupancy_report_response();
-    if (ret != ESP_OK) {
-        return ret;
-    }
-
     s_last_occupancy_state = occupied;
-    try_signal_wake_ready();
     return ESP_OK;
 }
 
@@ -483,7 +374,6 @@ void esp_zb_app_signal_handler(esp_zb_app_signal_t *signal_struct)
             ESP_LOGI(TAG, "Device started up in%s factory-reset mode",
                      esp_zb_bdb_is_factory_new() ? "" : " non");
             if (esp_zb_bdb_is_factory_new()) {
-                zigbee_motion_arm_radio_hold_ms(ZIGBEE_MOTION_REPAIR_HOLD_MS);
                 ESP_LOGI(TAG, "Start network steering");
                 link_status_led_set_steering();
                 esp_zb_bdb_start_top_level_commissioning(ESP_ZB_BDB_MODE_NETWORK_STEERING);
@@ -528,7 +418,6 @@ void esp_zb_app_signal_handler(esp_zb_app_signal_t *signal_struct)
                 ESP_LOGI(TAG, "ZDO Leave received");
             }
             zigbee_motion_mark_left();
-            zigbee_motion_arm_radio_hold_ms(ZIGBEE_MOTION_REPAIR_HOLD_MS);
             esp_zb_scheduler_alarm((esp_zb_callback_t)bdb_start_top_level_commissioning_cb,
                                    ESP_ZB_BDB_MODE_NETWORK_STEERING, 1000);
         } else if (err_status == ESP_OK) {
@@ -580,33 +469,8 @@ void esp_zb_app_signal_handler(esp_zb_app_signal_t *signal_struct)
 
 static esp_err_t zb_action_handler(esp_zb_core_action_callback_id_t callback_id, const void *message)
 {
-    zigbee_motion_note_coordinator_activity();
-
-    switch (callback_id) {
-    case ESP_ZB_CORE_SET_ATTR_VALUE_CB_ID:
-        if (message != NULL) {
-            zigbee_motion_on_off_attr_handler((const esp_zb_zcl_set_attr_value_message_t *)message);
-        }
-        break;
-    case ESP_ZB_CORE_CMD_DEFAULT_RESP_CB_ID:
-        if (message != NULL) {
-            const esp_zb_zcl_cmd_default_resp_message_t *resp = message;
-
-            if (s_report_waiting &&
-                resp->info.cluster == ESP_ZB_ZCL_CLUSTER_ID_OCCUPANCY_SENSING &&
-                resp->resp_to_cmd == ZCL_CMD_REPORT_ATTRIBUTES) {
-                if (resp->status_code == ESP_ZB_ZCL_STATUS_SUCCESS) {
-                    occupancy_report_complete(true);
-                } else {
-                    ESP_LOGW(TAG, "Occupancy report default response status: 0x%02x",
-                             resp->status_code);
-                    occupancy_report_complete(false);
-                }
-            }
-        }
-        break;
-    default:
-        break;
+    if (callback_id == ESP_ZB_CORE_SET_ATTR_VALUE_CB_ID && message != NULL) {
+        zigbee_motion_on_off_attr_handler((const esp_zb_zcl_set_attr_value_message_t *)message);
     }
 
     return ESP_OK;
@@ -669,7 +533,6 @@ static void esp_zb_task(void *pvParameters)
 
     esp_zb_device_register(ep_list);
     esp_zb_core_action_handler_register(zb_action_handler);
-    esp_zb_zcl_command_send_status_handler_register(occupancy_command_send_status_cb);
     esp_zb_set_rx_on_when_idle(false);
     esp_zb_sleep_enable(false);
     esp_zb_set_primary_network_channel_set(1 << ESP_ZB_PRIMARY_CHANNEL);
@@ -686,18 +549,10 @@ TaskHandle_t zigbee_motion_init(EventGroupHandle_t wake_events, EventBits_t read
 
     s_wake_events = wake_events;
     s_ready_bit = ready_bit;
-    s_report_events = xEventGroupCreate();
-    if (s_report_events == NULL) {
-        ESP_LOGE(TAG, "Failed to create report event group");
-        return NULL;
-    }
     s_joined = false;
     s_pending_valid = false;
     s_pending_occupied = false;
     s_last_occupancy_state = false;
-    s_report_waiting = false;
-    s_report_aps_ok = false;
-    s_radio_hold_deadline_tick = 0;
     s_light_enabled = true;
     zigbee_motion_load_on_off_from_nvs();
 
@@ -757,39 +612,6 @@ bool zigbee_motion_light_enabled(void)
 
 bool zigbee_motion_occupancy_intent_pending(void)
 {
-    return s_pending_valid || s_report_waiting;
-}
-
-uint32_t zigbee_motion_radio_hold_remaining_ms(void)
-{
-    if (s_radio_hold_deadline_tick == 0) {
-        return 0;
-    }
-
-    TickType_t now = xTaskGetTickCount();
-    if ((int32_t)(s_radio_hold_deadline_tick - now) <= 0) {
-        s_radio_hold_deadline_tick = 0;
-        return 0;
-    }
-
-    return (uint32_t)((s_radio_hold_deadline_tick - now) * portTICK_PERIOD_MS);
-}
-
-void zigbee_motion_wait_radio_hold(void)
-{
-    uint32_t remaining_ms = zigbee_motion_radio_hold_remaining_ms();
-    if (remaining_ms == 0) {
-        return;
-    }
-
-    ESP_LOGI(TAG, "Keeping radio up for leave/interview (%lu ms)", (unsigned long)remaining_ms);
-    while ((remaining_ms = zigbee_motion_radio_hold_remaining_ms()) > 0) {
-        uint32_t slice_ms = remaining_ms > 1000 ? 1000 : remaining_ms;
-        vTaskDelay(pdMS_TO_TICKS(slice_ms));
-    }
-    esp_zb_lock_acquire(portMAX_DELAY);
-    esp_zb_set_rx_on_when_idle(false);
-    esp_zb_lock_release();
-    ESP_LOGI(TAG, "Radio hold window closed");
+    return s_pending_valid;
 }
 

--- a/zigbee-motion-light/components/zigbee_motion/zigbee_motion.c
+++ b/zigbee-motion-light/components/zigbee_motion/zigbee_motion.c
@@ -300,10 +300,10 @@ static void monitor_task(void *pvParameters)
 
     ESP_LOGI(TAG, "Monitor task started");
 
-    vTaskDelay(pdMS_TO_TICKS(100));
+    motion_driver_wait_settled();
 
     for (;;) {
-        bool motion = motion_driver_get_state();
+        bool motion = motion_driver_get_state_debounced();
         ESP_LOGI(TAG, "Publishing occupancy (%s)", motion ? "OCCUPIED" : "UNOCCUPIED");
 
         if (send_occupancy_to_network(motion, false) == ESP_OK) {

--- a/zigbee-motion-light/components/zigbee_motion/zigbee_motion.h
+++ b/zigbee-motion-light/components/zigbee_motion/zigbee_motion.h
@@ -22,6 +22,15 @@ extern "C" {
 /* Zigbee RF channel (11–26); primary scan mask is (1 << channel) */
 #define ESP_ZB_PRIMARY_CHANNEL  25
 
+/** Stay awake after join so Z2M can interview (ms). */
+#define ZIGBEE_MOTION_INTERVIEW_HOLD_MS   (120 * 1000)
+
+/** Extend hold when coordinator sends ZCL traffic (ms). */
+#define ZIGBEE_MOTION_INTERVIEW_EXTEND_MS (60 * 1000)
+
+/** Stay awake after leave / factory-new for re-pairing (ms). */
+#define ZIGBEE_MOTION_REPAIR_HOLD_MS      (5 * 60 * 1000)
+
 /**
  * @brief Initialize Zigbee motion light component.
  *
@@ -29,7 +38,7 @@ extern "C" {
  * (Basic, Identify, On/Off, Occupancy Sensing), and starts the Zigbee task.
  *
  * @param wake_events Event group to signal when the Zigbee track is ready for sleep
- * @param ready_bit   Bit to set when joined, occupancy applied, and monitor done
+ * @param ready_bit   Bit to set when joined and occupancy report is acknowledged
  * @return Task handle on success, NULL on failure
  */
 TaskHandle_t zigbee_motion_init(EventGroupHandle_t wake_events, EventBits_t ready_bit);
@@ -38,7 +47,8 @@ TaskHandle_t zigbee_motion_init(EventGroupHandle_t wake_events, EventBits_t read
 /**
  * @brief Send occupancy report to Zigbee network.
  *
- * When joined, updates the Occupancy Sensing cluster on state change only.
+ * When joined, updates the Occupancy Sensing cluster and sends a report to the
+ * coordinator, waiting for the default response (or APS send OK on timeout).
  * When not yet joined, stores the latest requested state and flushes after join.
  *
  * @param occupied true if motion detected, false otherwise
@@ -57,19 +67,27 @@ esp_err_t zigbee_motion_publish_occupancy_refresh(bool occupied);
  */
 bool zigbee_motion_is_joined(void);
 
-
+/**
+ * @brief True when the coordinator On/Off state allows the motion LED strip.
+ *
+ * Persisted in NVS so deep-sleep wake cycles respect OFF before Zigbee rejoins.
+ */
+bool zigbee_motion_light_enabled(void);
 
 /**
- * @brief True while a requested occupancy value is still pending (queued before join, or must retry after a failed apply).
+ * @brief True while occupancy is queued before join or a report awaits coordinator response.
  */
 bool zigbee_motion_occupancy_intent_pending(void);
 
 /**
- * @brief Check if Zigbee task has finished.
- *
- * @return true if Zigbee task is finished, false otherwise
+ * @brief Milliseconds remaining in the post-leave / factory-new radio hold window.
  */
-bool zigbee_motion_is_finished(void);
+uint32_t zigbee_motion_radio_hold_remaining_ms(void);
+
+/**
+ * @brief Block until the radio hold window expires (leave / interview / re-pair).
+ */
+void zigbee_motion_wait_radio_hold(void);
 
 #ifdef __cplusplus
 }

--- a/zigbee-motion-light/components/zigbee_motion/zigbee_motion.h
+++ b/zigbee-motion-light/components/zigbee_motion/zigbee_motion.h
@@ -22,15 +22,6 @@ extern "C" {
 /* Zigbee RF channel (11–26); primary scan mask is (1 << channel) */
 #define ESP_ZB_PRIMARY_CHANNEL  25
 
-/** Stay awake after join so Z2M can interview (ms). */
-#define ZIGBEE_MOTION_INTERVIEW_HOLD_MS   (120 * 1000)
-
-/** Extend hold when coordinator sends ZCL traffic (ms). */
-#define ZIGBEE_MOTION_INTERVIEW_EXTEND_MS (60 * 1000)
-
-/** Stay awake after leave / factory-new for re-pairing (ms). */
-#define ZIGBEE_MOTION_REPAIR_HOLD_MS      (5 * 60 * 1000)
-
 /**
  * @brief Initialize Zigbee motion light component.
  *
@@ -38,7 +29,7 @@ extern "C" {
  * (Basic, Identify, On/Off, Occupancy Sensing), and starts the Zigbee task.
  *
  * @param wake_events Event group to signal when the Zigbee track is ready for sleep
- * @param ready_bit   Bit to set when joined and occupancy report is acknowledged
+ * @param ready_bit   Bit to set when joined and occupancy report is queued
  * @return Task handle on success, NULL on failure
  */
 TaskHandle_t zigbee_motion_init(EventGroupHandle_t wake_events, EventBits_t ready_bit);
@@ -47,8 +38,8 @@ TaskHandle_t zigbee_motion_init(EventGroupHandle_t wake_events, EventBits_t read
 /**
  * @brief Send occupancy report to Zigbee network.
  *
- * When joined, updates the Occupancy Sensing cluster and sends a report to the
- * coordinator, waiting for the default response (or APS send OK on timeout).
+ * When joined, updates the Occupancy Sensing cluster and queues a report to the
+ * coordinator (fire-and-forget on the Zigbee stack thread).
  * When not yet joined, stores the latest requested state and flushes after join.
  *
  * @param occupied true if motion detected, false otherwise
@@ -75,19 +66,9 @@ bool zigbee_motion_is_joined(void);
 bool zigbee_motion_light_enabled(void);
 
 /**
- * @brief True while occupancy is queued before join or a report awaits coordinator response.
+ * @brief True while occupancy is queued before join.
  */
 bool zigbee_motion_occupancy_intent_pending(void);
-
-/**
- * @brief Milliseconds remaining in the post-leave / factory-new radio hold window.
- */
-uint32_t zigbee_motion_radio_hold_remaining_ms(void);
-
-/**
- * @brief Block until the radio hold window expires (leave / interview / re-pair).
- */
-void zigbee_motion_wait_radio_hold(void);
 
 #ifdef __cplusplus
 }

--- a/zigbee-motion-light/docs/deep-sleep-fast-join-research.md
+++ b/zigbee-motion-light/docs/deep-sleep-fast-join-research.md
@@ -4,6 +4,8 @@
 **Date:** 2026-05-22  
 **Goal:** Collect everything relevant to rejoining the Zigbee network as quickly as possible after `esp_deep_sleep_start()` wake (full chip reset).
 
+> **Implementation status (2026-05):** The fixes described below are implemented in `zigbee_motion.c`. For operational docs, log examples, and test steps, see **[nvram-rejoin-and-diagnostics.md](./nvram-rejoin-and-diagnostics.md)**.
+
 ---
 
 ## Executive summary

--- a/zigbee-motion-light/docs/nvram-rejoin-and-diagnostics.md
+++ b/zigbee-motion-light/docs/nvram-rejoin-and-diagnostics.md
@@ -1,0 +1,252 @@
+# NVRAM Rejoin & Diagnostic Logging
+
+**Project:** `zigbee-motion-light`  
+**Component:** `components/zigbee_motion/zigbee_motion.c`  
+**Status:** Implemented and verified on hardware (deep sleep wake → fast rejoin)
+
+This document describes how the motion light rejoins a Zigbee network after deep sleep, how to read the NVRAM diagnostic logs, and what was fixed to make rejoin reliable.
+
+For background research (ZBOSS internals, partition layout, timing estimates), see [deep-sleep-fast-join-research.md](./deep-sleep-fast-join-research.md).
+
+---
+
+## Summary
+
+After `esp_deep_sleep_start()`, the chip performs a **full reset**. All RAM Zigbee state is lost, but network credentials persist in the **`zb_storage`** flash partition (16 KB in `partitions.csv`).
+
+The correct wake path is:
+
+1. Stack loads credentials from `zb_storage`
+2. ZBOSS re-associates with the saved parent on the saved channel
+3. Application receives `ESP_ZB_BDB_SIGNAL_DEVICE_REBOOT`
+4. Application marks the device joined and sends occupancy — **without** network steering
+
+Network steering is only for **factory-new** pairing or when stored credentials are invalid.
+
+---
+
+## Boot flow
+
+```text
+Deep sleep wake (full reset)
+        │
+        ▼
+esp_zb_start(false)  →  load zb_storage
+        │
+        ├─ factory_new=1  ──► NETWORK_STEERING  ──► first join
+        │
+        └─ factory_new=0  ──► stack rejoins parent
+                                    │
+                    ┌───────────────┴───────────────┐
+                    ▼                               ▼
+         DEVICE_REBOOT + valid network      still associating
+                    │                               │
+                    ▼                               ▼
+         mark_joined(), send occupancy     retry INITIALIZATION
+         (~0.7–2 s typical)                  (do NOT start steering)
+```
+
+Implementation lives in `esp_zb_app_signal_handler()` — cases `ESP_ZB_BDB_SIGNAL_DEVICE_FIRST_START`, `ESP_ZB_BDB_SIGNAL_DEVICE_REBOOT`, and `ESP_ZB_BDB_SIGNAL_STEERING`.
+
+---
+
+## NVRAM snapshot log
+
+Every important boot/rejoin event prints one line:
+
+```text
+I (700) ZIGBEE_MOTION: NVRAM snapshot [DEVICE_REBOOT]: factory_new=0 dev_joined=1 valid=1 PAN=0xa18f Ch=25 Addr=0xed51 ExtPAN=00:12:4b:00:31:df:99:9a
+```
+
+| Field | Meaning |
+|-------|---------|
+| `factory_new` | `1` = never joined / erased flash; `0` = credentials in `zb_storage` |
+| `dev_joined` | `esp_zb_bdb_dev_joined()` — stack considers itself on a network |
+| `valid` | Application check: joined **and** PAN/short address are not `0x0000`, `0xfffe`, or `0xffff` |
+| `PAN` | 16-bit PAN ID |
+| `Ch` | RF channel (11–26) |
+| `Addr` | Device short address on the network |
+| `ExtPAN` | Extended PAN ID (8 bytes, MSB first in log) |
+
+### Snapshot contexts
+
+| Context tag | When |
+|-------------|------|
+| `DEVICE_FIRST_START` | First boot after erase, before steering |
+| `DEVICE_REBOOT` | Successful reboot signal with saved network |
+| `BDB Device Reboot` | Failed reboot signal (may still be mid-rejoin) |
+| `STEERING join` | First-time join via network steering |
+| `STEERING invalid` | Steering returned OK but network state is bogus |
+
+There is no public API to dump the raw `zb_storage` blob. These snapshots are the practical way to verify that flash restore is working.
+
+---
+
+## Signal handler rules
+
+### `DEVICE_REBOOT` / `DEVICE_FIRST_START`
+
+**Success (`ESP_OK`):**
+
+- `factory_new` → start network steering (first pairing)
+- `!factory_new` + `valid=1` → **Rejoined from NVRAM** — lock channel, mark joined
+- `!factory_new` + `valid=0` → credentials corrupt; fall back to steering
+
+**Failure (`ESP_FAIL` or other):**
+
+- `valid=1` → treat as joined anyway (stack can report failure while network is already up)
+- `valid=0` + `!factory_new` → **Rejoin in progress, retrying initialization** — wait for stack, do not steer
+- otherwise → retry initialization
+
+### `STEERING`
+
+- Ignored if already joined (prevents duplicate join handling after a fast rejoin)
+- Used only for factory-new pairing or invalid NVRAM recovery
+
+### Helpers
+
+```c
+zigbee_motion_network_is_valid()      // rejects fake joins (0xffff PAN/addr)
+zigbee_motion_log_nvram_snapshot()    // one-line diagnostic dump
+zigbee_motion_lock_channel_from_stack() // restrict scans to joined channel after rejoin
+```
+
+---
+
+## What was broken (and fixed)
+
+### Problem 1: Steering on every wake
+
+Older code started network steering even when `zb_storage` had valid credentials. That forced a full channel scan (3–10+ s) instead of a fast parent rejoin (~0.7–2 s).
+
+**Fix:** On non-factory-reset reboot, mark joined from `DEVICE_REBOOT` when the network is valid. Only steer when `factory_new` or credentials are invalid.
+
+### Problem 2: Misinterpreting `DEVICE_REBOOT` + `ESP_FAIL`
+
+During rejoin, the stack may emit several `DEVICE_REBOOT` signals with `ESP_FAIL` **before** association completes. Early snapshots show `dev_joined=0 valid=0` but PAN/Ch/Addr already loaded from NVRAM — that is normal, not a storage failure.
+
+The old handler logged *"Silent rejoin failed, falling back to network steering"* and scheduled steering. That interfered with the in-progress rejoin and stretched wake time to ~8 s.
+
+**Fix:**
+
+1. If `valid=1` on a failed signal → mark joined immediately
+2. If `valid=0` and NVRAM present → retry `INITIALIZATION`, not steering
+
+---
+
+## Expected logs
+
+### Good — fast rejoin after deep sleep (~700 ms–2 s)
+
+```text
+I (700) ZIGBEE_MOTION: NVRAM snapshot [DEVICE_REBOOT]: factory_new=0 dev_joined=1 valid=1 PAN=0xa18f Ch=25 Addr=0xed51 ExtPAN=...
+I (700) ZIGBEE_MOTION: Device started up in non factory-reset mode
+I (700) ZIGBEE_MOTION: Rejoined from NVRAM
+I (710) ZIGBEE_MOTION: Monitor task created after joining
+I (8656) MOTION_LIGHT: Wake cycle complete (bits 0x3), entering deep sleep
+```
+
+Checklist:
+
+- Same `PAN`, `Ch`, `Addr`, `ExtPAN` across wake cycles
+- No `Start network steering` after sleep
+- No `Silent rejoin failed` message
+
+### Good — slow rejoin, fixed handler
+
+Rejoin can still take a few seconds if the parent is slow to respond. With the fix you should see initialization retries, not steering:
+
+```text
+I (5726) ZIGBEE_MOTION: NVRAM snapshot [BDB Device Reboot]: factory_new=0 dev_joined=0 valid=0 PAN=0xa18f Ch=25 Addr=0xed51 ExtPAN=...
+W (5726) ZIGBEE_MOTION: BDB Device Reboot failed with status: ESP_FAIL
+W (5736) ZIGBEE_MOTION: Rejoin in progress, retrying initialization
+...
+I (8316) ZIGBEE_MOTION: NVRAM snapshot [BDB Device Reboot]: factory_new=0 dev_joined=1 valid=1 PAN=0xa18f Ch=25 Addr=0xed51 ExtPAN=...
+I (8316) ZIGBEE_MOTION: Rejoined from NVRAM (BDB Device Reboot reported ESP_FAIL)
+```
+
+PAN/Ch/Addr stay consistent — **storage is fine**; the stack just needed more time.
+
+### Bad — storage empty or erased
+
+```text
+I (...) ZIGBEE_MOTION: NVRAM snapshot [DEVICE_FIRST_START]: factory_new=1 dev_joined=0 valid=0 PAN=0xffff Ch=0 Addr=0xffff ExtPAN=00:00:...
+I (...) ZIGBEE_MOTION: Device started up in factory-reset mode
+I (...) ZIGBEE_MOTION: Start network steering
+```
+
+Requires coordinator permit join and first-time pairing.
+
+### Bad — credentials present but permanently invalid
+
+```text
+I (...) NVRAM snapshot [DEVICE_REBOOT]: factory_new=0 dev_joined=0 valid=0 PAN=0xffff Ch=0 Addr=0xfffe ExtPAN=...
+W (...) NVRAM data present but network invalid, falling back to steering
+```
+
+Network may have been reset on the coordinator, or `zb_storage` is corrupt. Erase flash and re-pair, or leave/join from the coordinator.
+
+---
+
+## How to test
+
+### 1. First pairing (after erase)
+
+```bash
+idf.py -p /dev/cu.usbmodem1101 erase-flash flash monitor
+```
+
+Open permit join on the coordinator. Expect `STEERING join` snapshot with `valid=1`. Save PAN/Ch/Addr/ExtPAN from the log.
+
+### 2. Deep sleep rejoin
+
+Trigger motion (or wait for a wake cycle). After `Entering deep sleep...`, trigger another wake. Compare the new `DEVICE_REBOOT` snapshot to the saved values — they must match.
+
+### 3. Regression check
+
+After several sleep/wake cycles, confirm:
+
+- Wake-to-joined time stays under ~2 s in the common case
+- No steering on non-factory wakes
+- Occupancy reports reach the coordinator
+
+### 4. Firmware update without re-pairing
+
+```bash
+idf.py -p /dev/cu.usbmodem1101 flash monitor   # no erase-flash
+```
+
+`zb_storage` is preserved; device should rejoin on first boot with the same PAN/Ch/Addr.
+
+---
+
+## Flash erase reference
+
+| Command | Effect |
+|---------|--------|
+| `idf.py -p PORT erase-flash` | Wipes app, NVS, **`zb_storage`** — factory-new device |
+| `idf.py -p PORT flash` | Updates firmware only; keeps join credentials |
+| `idf.py -p PORT erase-flash flash` | Clean slate + new firmware (use for pairing tests) |
+
+---
+
+## Related files
+
+| File | Role |
+|------|------|
+| `components/zigbee_motion/zigbee_motion.c` | Signal handler, NVRAM snapshots, join logic |
+| `main/main.c` | Supervisor waits for Zigbee track, then deep sleep |
+| `partitions.csv` | `zb_storage` partition at `0xf1000`, 16 KB |
+| `docs/deep-sleep-fast-join-research.md` | Research notes, ZBOSS log signatures, partition details |
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause | Action |
+|---------|--------------|--------|
+| Steering on every wake | Old firmware or `factory_new=1` | Flash current build; avoid `erase-flash` between tests |
+| `valid=0` but PAN/Addr look real | Rejoin still in progress | Wait; should resolve with init retry (not steering) |
+| Different PAN/Addr after wake | Coordinator changed or storage corrupt | Re-pair after `erase-flash` |
+| Join takes 8+ s with steering fallback | Pre-fix firmware | Flash build with init-retry fix |
+| `STEERING join` after `Rejoined from NVRAM` | Stray steering scheduled during rejoin | Fixed: steering ignored when already joined |

--- a/zigbee-motion-light/kicad/esp32-c6-motion-light/esp32-c6-motion-light.kicad_pcb
+++ b/zigbee-motion-light/kicad/esp32-c6-motion-light/esp32-c6-motion-light.kicad_pcb
@@ -3946,7 +3946,7 @@
 				)
 			)
 		)
-		(property "LCSC Part" "C17557"
+		(property "LCSC Part" "C17556"
 			(at 0 0 90)
 			(layer "F.Fab")
 			(hide yes)

--- a/zigbee-motion-light/main/CMakeLists.txt
+++ b/zigbee-motion-light/main/CMakeLists.txt
@@ -1,5 +1,5 @@
 idf_component_register(
     SRC_DIRS  "."
     INCLUDE_DIRS "."
-    PRIV_REQUIRES nvs_flash esp_timer driver espressif__esp-zigbee-lib espressif__esp-zboss-lib espressif__led_strip motion_driver light_driver link_status_led zigbee_motion light_animation
+    PRIV_REQUIRES nvs_flash esp_timer driver espressif__esp-zigbee-lib espressif__esp-zboss-lib espressif__led_strip motion_driver light_driver link_status_led motion_status_led zigbee_motion light_animation
 )

--- a/zigbee-motion-light/main/esp_zb_motion_light.h
+++ b/zigbee-motion-light/main/esp_zb_motion_light.h
@@ -25,9 +25,6 @@
 #define ESP_ZB_ZCL_ATTR_OCCUPANCY_ID                      0x0000
 #define ESP_ZB_ZCL_ATTR_OCCUPANCY_SENSOR_TYPE_ID         0x0001
 
-/* On/Off cluster attributes */
-#define ESP_ZB_ZCL_ATTR_ON_OFF_ID                        0x0000
-
 /**
  * @brief Initialize Zigbee motion light.
  *

--- a/zigbee-motion-light/main/main.c
+++ b/zigbee-motion-light/main/main.c
@@ -91,9 +91,9 @@ void app_main(void)
         return;
     }
 
-    ESP_LOGI(TAG, "Supervisor waiting for occupancy report response (Zigbee)");
+    ESP_LOGI(TAG, "Supervisor waiting for occupancy report (Zigbee)");
     xEventGroupWaitBits(wake_events, WAKE_ZB_READY_BIT, pdFALSE, pdTRUE, portMAX_DELAY);
 
-    ESP_LOGI(TAG, "Occupancy acknowledged, entering deep sleep");
+    ESP_LOGI(TAG, "Occupancy queued, entering deep sleep");
     enter_deep_sleep();
 }

--- a/zigbee-motion-light/main/main.c
+++ b/zigbee-motion-light/main/main.c
@@ -22,6 +22,7 @@
 #include "motion_driver.h"
 #include "zigbee_motion.h"
 #include "link_status_led.h"
+#include "motion_status_led.h"
 #include "light_animation.h"
 
 static const char *TAG = "MOTION_LIGHT";
@@ -41,10 +42,12 @@ static void enter_deep_sleep(void)
     vTaskDelay(pdMS_TO_TICKS(20));
 
     link_status_led_off();
+    motion_status_led_off();
     light_driver_set_power(LIGHT_DEFAULT_OFF);
 
     /* If PIR is still HIGH, GPIO wake fires immediately and looks like no sleep. */
     motion_driver_wait_until_clear(2500);
+    motion_status_led_set(motion_driver_get_state());
 
     motion_driver_configure_deep_sleep_wakeup();
     ESP_ERROR_CHECK(esp_sleep_enable_timer_wakeup(DEEP_SLEEP_TIMER_INTERVAL_SEC * 1000000ULL));
@@ -64,6 +67,7 @@ void app_main(void)
     light_driver_init();
     light_driver_set_rgb(0, 0, 0);
     link_status_led_init();
+    motion_status_led_init();
     motion_driver_init();
 
     esp_sleep_wakeup_cause_t wakeup_reason = esp_sleep_get_wakeup_cause();
@@ -91,9 +95,10 @@ void app_main(void)
         return;
     }
 
-    ESP_LOGI(TAG, "Supervisor waiting for occupancy report (Zigbee)");
-    xEventGroupWaitBits(wake_events, WAKE_ZB_READY_BIT, pdFALSE, pdTRUE, portMAX_DELAY);
+    ESP_LOGI(TAG, "Supervisor waiting for Zigbee report and animation");
+    xEventGroupWaitBits(wake_events, WAKE_ZB_READY_BIT | WAKE_ANIM_DONE_BIT,
+                        pdFALSE, pdTRUE, portMAX_DELAY);
 
-    ESP_LOGI(TAG, "Occupancy queued, entering deep sleep");
+    ESP_LOGI(TAG, "Wake cycle complete, entering deep sleep");
     enter_deep_sleep();
 }

--- a/zigbee-motion-light/main/main.c
+++ b/zigbee-motion-light/main/main.c
@@ -32,9 +32,6 @@ static const char *TAG = "MOTION_LIGHT";
 #define WAKE_ANIM_DONE_BIT  BIT0
 #define WAKE_ZB_READY_BIT   BIT1
 
-/* Cosmetic strip may finish before occupancy is sent; only ZB gates sleep. */
-#define ANIM_GRACE_AFTER_ZB_MS  500
-
 /* ───────────────────── Deep Sleep ───────────────────── */
 
 static void enter_deep_sleep(void)
@@ -94,20 +91,9 @@ void app_main(void)
         return;
     }
 
-    ESP_LOGI(TAG, "Supervisor waiting for occupancy track (Zigbee)");
+    ESP_LOGI(TAG, "Supervisor waiting for occupancy report response (Zigbee)");
     xEventGroupWaitBits(wake_events, WAKE_ZB_READY_BIT, pdFALSE, pdTRUE, portMAX_DELAY);
 
-    EventBits_t bits = xEventGroupGetBits(wake_events);
-    ESP_LOGI(TAG, "Occupancy track ready (bits 0x%lx)", (unsigned long)bits);
-
-    if ((bits & WAKE_ANIM_DONE_BIT) == 0) {
-        ESP_LOGI(TAG, "Waiting up to %d ms for animation track", ANIM_GRACE_AFTER_ZB_MS);
-        xEventGroupWaitBits(wake_events, WAKE_ANIM_DONE_BIT, pdFALSE, pdTRUE,
-                            pdMS_TO_TICKS(ANIM_GRACE_AFTER_ZB_MS));
-        bits = xEventGroupGetBits(wake_events);
-    }
-
-    ESP_LOGI(TAG, "Wake cycle complete (bits 0x%lx), entering deep sleep",
-             (unsigned long)bits);
+    ESP_LOGI(TAG, "Occupancy acknowledged, entering deep sleep");
     enter_deep_sleep();
 }


### PR DESCRIPTION
## Summary

Improves the Zigbee motion light firmware for deep-sleep operation, coordinator compatibility, and clearer on-device feedback.

- **Join/rejoin**: NVRAM-backed fast rejoin after deep-sleep wake; faster sleep after fire-and-forget occupancy reports.
- **HA behavior**: On/Off gate for strip animation, occupancy ack handling, Z2M repair hooks.
- **LED layout**: Pixel 0 = Zigbee link; pixel 1 = motion (green clear / red detected) via new `motion_status_led`; pixels 2+ = timed main sweep (30s cap) instead of holding until PIR drops.
- **PIR**: Settle wait and debounced read after GPIO wake to avoid false triggers.

Includes a minor KiCad PCB touch-up in the same tree.

## Test plan

- [ ] `cd zigbee-motion-light && idf.py build` (ESP32-C6 target)
- [ ] Flash, join network, verify occupancy and On/Off from coordinator
- [ ] Wake on motion: status LED on pixel 1, animation on upper pixels, deep sleep after cycle
- [ ] Cold boot / sleep wake: rejoin without full re-pair
